### PR TITLE
Fix getDimensions calculation

### DIFF
--- a/interface/gui/draw/component/Component.cpp
+++ b/interface/gui/draw/component/Component.cpp
@@ -43,7 +43,7 @@ Origin Component::getOrigin() {
 Dimensions Component::getDimensions() {
 	RECT rect;
 	GetWindowRect(handle, &rect);
-	return { (rect.top - rect.bottom), (rect.right - rect.left) };
+        return { rect.right - rect.left, rect.bottom - rect.top };
 }
 
 HBRUSH Component::createBrush(uint32_t rgb) {


### PR DESCRIPTION
## Summary
- fix the order of width and height returned by `getDimensions`

## Testing
- `grep -R "getDimensions" -n`


------
https://chatgpt.com/codex/tasks/task_e_68548b84b1cc8332987521bb47242651