### PR TITLE
Add MoviePack support to GUI extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There are two flavours of Decima Explorer, one that can be run from the command 
 
 ### GUI
 
-With the GUI version you can select the initial data directory of the game and it will populate a file list based on the games cache prefetch. You can use the keyboard shortcut Ctrl+F to filter this list for the items you are interested in. You can select all the items with Ctrl+A or by Ctrl or shift clicking. With the items you wish to extract selected you can press the extract button and choose a directory in which to extract, when extracting multiple files with the GUI extraction will be multithreaded and should use all available cores. It is currently not possible to extract .mpk archives with the GUI.
+With the GUI version you can select the initial data directory of the game and it will populate a file list based on the games cache prefetch. You can use the keyboard shortcut Ctrl+F to filter this list for the items you are interested in. You can select all the items with Ctrl+A or by Ctrl or shift clicking. With the items you wish to extract selected you can press the extract button and choose a directory in which to extract, when extracting multiple files with the GUI extraction will be multithreaded and should use all available cores.
 
 There is also a separate GUI for packing and repacking files. I decided to separate this for now for a cleaner UX. When repacking you must first select a folder that contains the complete path for a file, this is because the directory is used when hashing. You can then select and output, if it is a bin file that already exists it will attempt to repack that file. If it is a file that doesnt exist it will pack the files into a new bin file.
 

--- a/decima/archive/mpk/ArchiveMoviePack.h
+++ b/decima/archive/mpk/ArchiveMoviePack.h
@@ -22,7 +22,7 @@ private:
 	const uint64_t MAXSTREAM = 0x100000;
 	const std::string extension = ".mpk";
 	ArchiveMoviePackHeader header = { 0 };
-	std::vector<ArchiveMoviePackFileEntry> fileTable;
+       std::vector<ArchiveMoviePackFileEntry> fileTable;
 
 	uint32_t saltA[4] = { 0x833237C3, 0xBA5CD4B6, 0x3371A06B, 0xAEA7EDB2 };
 	uint32_t saltB[4] = { 0xCE857276, 0x9ACC40E8, 0x8242DBD6, 0xCF703987, };
@@ -37,9 +37,10 @@ private:
 	void saveStream(FILE* input, FILE* output, uint64_t size, uint32_t* key, uint64_t pass);
 	void extract(ArchiveMoviePackFileEntry fileEntry, std::string output);
 public:
-	ArchiveMoviePack(std::string filename);
-	~ArchiveMoviePack();
-	int open() override;
-	int extractFile(uint32_t id, std::string output);
-	int extractFile(std::string filename, std::string output, bool suppressError = 0);
+       ArchiveMoviePack(std::string filename);
+       ~ArchiveMoviePack();
+       int open() override;
+       int extractFile(uint32_t id, std::string output);
+       int extractFile(std::string filename, std::string output, bool suppressError = 0);
+       const std::vector<ArchiveMoviePackFileEntry>& getFileTable() { return fileTable; }
 };

--- a/interface/Interface.cpp
+++ b/interface/Interface.cpp
@@ -22,26 +22,41 @@ int32_t Interface::getProgress() {
 }
 
 void Interface::buildFileMap(const char* fileDirectory) {
-	availableFiles = getFilesFromDirectory(fileDirectory, ".bin");
+        availableFiles = getFilesFromDirectory(fileDirectory, ".bin");
+        std::vector<std::string> mpkFiles = getFilesFromDirectory(fileDirectory, ".mpk");
+        availableFiles.insert(availableFiles.end(), mpkFiles.begin(), mpkFiles.end());
 
-	for (int i = 0; i < availableFiles.size(); i++) {
-		ArchiveBin decimaArchive(availableFiles[i].c_str());
-		decimaArchive.setMessageHandler(this);
-		if (!decimaArchive.open()) continue;
+        for (int i = 0; i < availableFiles.size(); i++) {
+                std::string ext = getFileExtension(availableFiles[i]);
 
-		std::vector <BinFileEntry> fileTable = decimaArchive.getFileTable();
+                if (ext == "mpk") {
+                        ArchiveMoviePack moviePack(availableFiles[i].c_str());
+                        moviePack.setMessageHandler(this);
+                        if (!moviePack.open()) continue;
 
-		for (int j = 0; j < fileTable.size(); j++) {
-			fileMap[fileTable[j].hash] = availableFiles[i].c_str();
-		}
-	}
+                        auto fileTable = moviePack.getFileTable();
+                        for (int j = 0; j < fileTable.size(); j++) {
+                                fileMap[fileTable[j].hash] = availableFiles[i].c_str();
+                        }
+                } else {
+                        ArchiveBin decimaArchive(availableFiles[i].c_str());
+                        decimaArchive.setMessageHandler(this);
+                        if (!decimaArchive.open()) continue;
+
+                        std::vector <BinFileEntry> fileTable = decimaArchive.getFileTable();
+
+                        for (int j = 0; j < fileTable.size(); j++) {
+                                fileMap[fileTable[j].hash] = availableFiles[i].c_str();
+                        }
+                }
+        }
 }
 
-const char* Interface::getContainingBinFile(const char* filename) {
-	std::string fname = filename;
-	if (!hasExtension(fname)) addExtension(fname, "core");
-	uint64_t hash = getFileHash(fname);
-	return fileMap[hash];
+const char* Interface::getContainingArchiveFile(const char* filename) {
+        std::string fname = filename;
+        if (!hasExtension(fname)) addExtension(fname, "core");
+        uint64_t hash = getFileHash(fname);
+        return fileMap[hash];
 }
 
 //TODO make dedicated thread handler class
@@ -86,7 +101,7 @@ void Interface::setupOutput(const std::string& output) {
 }
 
 void Interface::directoryExtract(const char* filename, std::string output) {
-	const char* binFile = getContainingBinFile(filename);
+       const char* binFile = getContainingArchiveFile(filename);
 	if (binFile == NULL) return;
 	setupOutput(output);
 	extract(binFile, filename, output.c_str());

--- a/interface/Interface.h
+++ b/interface/Interface.h
@@ -36,10 +36,10 @@ protected:
 	void updateProgress(int count);
 	int initPrefetch(const char* binFile);
 	void setupOutput(const std::string& output);
-	void buildFileMap(const char* fileDirectory);
-	void swap(const char* dataDir, const char* swapFile);
-	const char* getContainingBinFile(const char* filename);
-	std::vector<std::string> getFiles(const std::string& directory);
+        void buildFileMap(const char* fileDirectory);
+        void swap(const char* dataDir, const char* swapFile);
+        const char* getContainingArchiveFile(const char* filename);
+        std::vector<std::string> getFiles(const std::string& directory);
 	void directoryExtract(const char* filename, std::string output);
 	int extract(const char* archiveFile, int id, const char* output);
 	int extract(const char* archiveFile, const char* input, const char* output);


### PR DESCRIPTION
## Summary
- support `.mpk` archives in Interface file map
- expose `ArchiveMoviePack` file table
- lookup containing archive for any file type
- document GUI capability for `.mpk` extraction

## Testing
- `g++ -std=c++11 -c interface/Interface.cpp -o /tmp/interface.o` *(fails: fileutils.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68548b666834833285d8661e33b725e4