### PR TITLE
Fix case-sensitive include paths

### DIFF
--- a/decima/file/DecimaCore.h
+++ b/decima/file/DecimaCore.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <fstream>
-#include "../../utils/fileutils.h"
+#include "../../utils/Fileutils.h"
 
 typedef std::vector<uint8_t> DataBuffer;
 

--- a/interface/Interface.h
+++ b/interface/Interface.h
@@ -9,7 +9,7 @@
 #include "../decima/archive/mpk/ArchiveMoviePack.h"
 #include "../decima/archive/bin/initial/BinInitial.h"
 #include "../utils/Arrayutils.h"
-#include "../utils/NumUtils.h"
+#include "../utils/Numutils.h"
 #include "../utils/Msgutils.h"
 
 class Interface : public MessageHandler {

--- a/interface/gui/draw/component/window/WindowComponent.h
+++ b/interface/gui/draw/component/window/WindowComponent.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "../component.h"
+#include "../Component.h"
 #include "../../../res/res.h"
 
 class WindowCaller {


### PR DESCRIPTION
## Summary
- fix include path casing for Fileutils and Numutils
- correct `WindowComponent` header include casing

## Testing
- `g++ -c -std=c++17 interface/Interface.cpp -I./ -Iutils -Idecima -Iinterface` *(fails: io.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548b725e60833294a92b4b321fa702